### PR TITLE
Adds support for the new react-native condition

### DIFF
--- a/.changeset/modern-chairs-impress.md
+++ b/.changeset/modern-chairs-impress.md
@@ -2,4 +2,4 @@
 "isows": patch
 ---
 
-Adds support for the new react-native export condition
+Added `react-native` export to `package.json#exports`.

--- a/.changeset/modern-chairs-impress.md
+++ b/.changeset/modern-chairs-impress.md
@@ -1,0 +1,5 @@
+---
+"isows": patch
+---
+
+Adds support for the new react-native export condition

--- a/src/package.json
+++ b/src/package.json
@@ -25,7 +25,8 @@
 			"browser": "./_esm/native.js",
 			"deno": "./_esm/native.js",
 			"import": "./_esm/index.js",
-			"default": "./_cjs/index.js"
+			"default": "./_cjs/index.js",
+			"react-native": "./_esm/native.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/src/package.json
+++ b/src/package.json
@@ -25,8 +25,8 @@
 			"browser": "./_esm/native.js",
 			"deno": "./_esm/native.js",
 			"import": "./_esm/index.js",
-			"default": "./_cjs/index.js",
-			"react-native": "./_esm/native.js"
+			"react-native": "./_esm/native.js",
+			"default": "./_cjs/index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/src/package.json
+++ b/src/package.json
@@ -24,8 +24,8 @@
 			"bun": "./_esm/native.js",
 			"browser": "./_esm/native.js",
 			"deno": "./_esm/native.js",
-			"import": "./_esm/index.js",
 			"react-native": "./_esm/native.js",
+			"import": "./_esm/index.js",
 			"default": "./_cjs/index.js"
 		},
 		"./package.json": "./package.json"


### PR DESCRIPTION
Adds support for the updated `react-native` community condition:

https://metrobundler.dev/docs/package-exports/#replacing-browser-and-react-native-fields

Tested by adding this new condition to the package from a newly created react-native app.