### PR TITLE
Add `worked` conditional export

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,7 @@
       "bun": "./_esm/native.js",
       "browser": "./_esm/native.js",
       "deno": "./_esm/native.js",
+      "worked": "./_esm/native.js",
       "import": "./_esm/index.js",
       "react-native": "./_esm/native.js",
       "default": "./_cjs/index.js"


### PR DESCRIPTION
Given
* `worked` is the conditional export for Cloudflare [[1]](https://developers.cloudflare.com/workers/wrangler/bundling/#conditional-exports) [[2]](https://runtime-keys.proposal.wintercg.org/#workerd).

* Cloudflare supports Websockets natively [[3]](https://developers.cloudflare.com/workers/runtime-apis/websockets).

We can add `worked` support!

Fix https://github.com/surrealdb/surrealdb.js/issues/329