### PR TITLE
fix: rename conditional export from `worked` to `workerd`

### DIFF
--- a/.changeset/popular-donuts-compare.md
+++ b/.changeset/popular-donuts-compare.md
@@ -2,4 +2,4 @@
 "isows": patch
 ---
 
-Rename conditional export `worked` to `workerd` in `package.json#exports`.
+Renamed conditional export `worked` to `workerd` in `package.json#exports`.

--- a/.changeset/popular-donuts-compare.md
+++ b/.changeset/popular-donuts-compare.md
@@ -1,0 +1,5 @@
+---
+"isows": patch
+---
+
+Rename conditional export `worked` to `workerd` in `package.json#exports`.

--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,7 @@
       "bun": "./_esm/native.js",
       "browser": "./_esm/native.js",
       "deno": "./_esm/native.js",
-      "worked": "./_esm/native.js",
+      "workerd": "./_esm/native.js",
       "import": "./_esm/index.js",
       "react-native": "./_esm/native.js",
       "default": "./_cjs/index.js"


### PR DESCRIPTION
In #12 the runtime key is wrong. This pull request sets the correct runtime key from `worked` to `workerd`.
(see [wintergc](https://runtime-keys.proposal.wintercg.org/#workerd) and [cloudflare](https://developers.cloudflare.com/workers/wrangler/bundling/#conditional-exports))