### PR TITLE
chore: update repo urls to match new org name

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.3/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "wagmi-dev/isows" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "wevm/isows" }],
   "commit": false,
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/friendly-students-wink.md
+++ b/.changeset/friendly-students-wink.md
@@ -1,0 +1,5 @@
+---
+"isows": patch
+---
+
+Update organization name in repository URLs from `wagmi-dev` to `wevm`.

--- a/src/package.json
+++ b/src/package.json
@@ -35,12 +35,12 @@
     "ws": "*"
   },
   "license": "MIT",
-  "repository": "wagmi-dev/isows",
+  "repository": "wevm/isows",
   "authors": ["jxom.eth"],
   "funding": [
     {
       "type": "github",
-      "url": "https://github.com/sponsors/wagmi-dev"
+      "url": "https://github.com/sponsors/wevm"
     }
   ],
   "keywords": ["isomorphic", "websocket", "ws", "node", "browser"]


### PR DESCRIPTION
This updates all repo urls to match the new organization name (`wagmi-dev` -> `wevm`).