### PR TITLE
fix: moves the `react-native` key in `exports` back before `import`

### DIFF
--- a/.changeset/neat-cycles-change.md
+++ b/.changeset/neat-cycles-change.md
@@ -2,4 +2,4 @@
 "isows": patch
 ---
 
-Fixes `react-native` export in `package.json#exports`.
+Fixed `react-native` export in `package.json#exports`.

--- a/.changeset/neat-cycles-change.md
+++ b/.changeset/neat-cycles-change.md
@@ -1,0 +1,5 @@
+---
+"isows": patch
+---
+
+Fixes `react-native` export in `package.json#exports`.

--- a/src/package.json
+++ b/src/package.json
@@ -25,8 +25,8 @@
       "browser": "./_esm/native.js",
       "deno": "./_esm/native.js",
       "workerd": "./_esm/native.js",
-      "import": "./_esm/index.js",
       "react-native": "./_esm/native.js",
+      "import": "./_esm/index.js",
       "default": "./_cjs/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Moves the key introduced in 1d0e496db949a59ec6d3e635522f42b69daa52b7, before the `import` key.
However, keys were incorrectly flipped in bf52424dce7c751c0ee56490ac32787369d9272d.

This resoluts in an incorrect resolution as [key order matters](https://nodejs.org/docs/latest-v19.x/api/packages.html#conditional-exports).